### PR TITLE
Improve UX for PC users

### DIFF
--- a/main.css
+++ b/main.css
@@ -229,7 +229,7 @@ body {
 @media (min-width: 720px) {
     .menu-category {
         scroll-snap-align: start;
-        height: 75%;
+        height: 85%;
         width: 50%;
         flex: 0 0 auto;
     }
@@ -237,7 +237,7 @@ body {
 
 @media (min-width: 1440px) {
     .menu-category {
-        width: calc(100% / 3);
+        width: calc(100% / 4);
     }
 }
 


### PR DESCRIPTION
A fix for #2. Does not use the suggested method in #2, but lazily increase the height to `85vh`. Also changes `width` of `menu-category` to 25% to eliminate scrolling on PC.

---
Before:
![before](https://github.com/aryanpingle/Mess-Menu/assets/35228810/3d40413f-f48e-409a-9026-ae05cd388c80)

After:
![after](https://github.com/aryanpingle/Mess-Menu/assets/35228810/afb0b7cf-5437-4927-8bd3-691b327de56d)
